### PR TITLE
fix: Correct import path for index.css in Canvas component

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { getCssVariableString } from '@/lib/utils'
-import cssContent from '../../index.css?raw'
+import cssContent from '../index.css?raw'
 
 interface CanvasProps {
   htmlContent: string | null


### PR DESCRIPTION
This commit fixes a build error caused by an incorrect path in an import statement. The `Canvas.tsx` component was trying to import `../../index.css?raw`, which was incorrect.

The path has been corrected to `../index.css?raw` to ensure the Vite dev server can resolve the module correctly.